### PR TITLE
Fix <a> tag styling

### DIFF
--- a/public/static/css/app.bundle.css
+++ b/public/static/css/app.bundle.css
@@ -19252,7 +19252,7 @@ a,body,div,html,p,span {
 }
 
 a {
-    color: #E34A21
+    color: #8e44ad;
 }
 
 .btn {


### PR DESCRIPTION
### DETAIL
Currently the styling for a tag is WHITE. Which causing the link become invisible in the UI result
![image](https://github.com/user-attachments/assets/9595698f-88e5-40b6-96d1-fd9614e7a300)


![image](https://github.com/user-attachments/assets/0e5626de-ec09-4ccf-8717-2c00ba452ce9)
